### PR TITLE
expose utils to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gr8",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "ⓖⓡ⑧ FUNctional CSS shorthand utilities",
   "main": "dist/gr8.js",
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -222,5 +222,9 @@ module.exports = function (options) {
     return styleNode
   }
 
+  api.utils = function () {
+    return getFormattedUtils()
+  }
+
   return api
 }


### PR DESCRIPTION
i’m wanting to use the utilities to generate a ui for creating gr8 blocks. to do this, i need to access the internal utils object. this pull request simply exposes the utils using the method `.utils()`.