### PR TITLE
Add TypeScript declaration file

### DIFF
--- a/dist/main.d.ts
+++ b/dist/main.d.ts
@@ -1,0 +1,48 @@
+declare namespace gr8 {
+  interface Options {
+    spacing?: number[] | number
+    fontSize?: number[] | number
+    lineHeight?: number[] | number
+    size?: number[] | number
+    viewport?: number[] | number
+    zIndex?: number[] | number
+    order?: number[] | number
+    opacity?: number[] | number
+    aspect?: number[] | number
+    textColumns?: number[] | number
+    unit?: string
+    nested?: boolean
+    responsive?: boolean
+    attribute?: boolean
+    max?: boolean
+    breakpoints?: { [k: string]: string }
+  }
+
+  type Vals = string[] | number[] | { [k: string]: string } | { [k: string]: number }
+
+  interface UtilityOptions {
+    vals: Vals
+    prop: string | string[][]
+    prefix?: string
+    suffix?: string
+    hyphenate?: boolean
+    unit?: string
+    transform?: (val: number | string) => number | string
+  }
+
+  type RemovableUtility = 'column.column' | 'column.offset' | 'column.nestedColumn' | 'column.nestedOffset' | 'margin.margin' | 'margin.marginX' | 'margin.marginY' | 'padding.padding' | 'padding.paddingX' | 'padding.paddingY' | 'opacity | background.size' | 'background.position' | 'background.repeat' | 'flex.display' | 'flex.align' | 'flex.direction' | 'flex.justify' | 'flex.wrap' | 'flex.flex' | 'flex.order' | 'flex.orderSpecial' | 'display | float.float' | 'float.clear' | 'overflow' | 'positioning.position' | 'positioning.placement' | 'positioning.zindex' | 'size.size' | 'size.viewportWidth' | 'size.viewportHeight' | 'size.viewportMinWidth' | 'size.viewportMinHeight' | 'size.viewportMaxWidth' | 'size.viewportMaxHeight' | 'size.aspect' | 'type.fontSize' | 'type.lineHeight' | 'type.fontStyle' | 'type.fontWeight' | 'type.textAlign' | 'type.textOverflow' | 'type.textDecoration' | 'type.textTransform' | 'type.verticalAlign' | 'type.whiteSpace' | 'type.textColumn' | 'misc.cursor' | 'misc.userSelect' | 'misc.pointerEvents' | 'dev'
+
+  interface Css {
+    toString: () => string
+    add: (options: gr8.UtilityOptions) => void
+    reset: () => void
+    attach: () => HTMLStyleElement
+    remove: (key: RemovableUtility | RemovableUtility[]) => void
+  }
+}
+
+declare function gr8(options?: gr8.Options): gr8.Css
+
+declare module 'gr8' {
+  export = gr8
+}

--- a/main.d.ts
+++ b/main.d.ts
@@ -1,0 +1,48 @@
+declare namespace gr8 {
+  interface Options {
+    spacing?: number[] | number
+    fontSize?: number[] | number
+    lineHeight?: number[] | number
+    size?: number[] | number
+    viewport?: number[] | number
+    zIndex?: number[] | number
+    order?: number[] | number
+    opacity?: number[] | number
+    aspect?: number[] | number
+    textColumns?: number[] | number
+    unit?: string
+    nested?: boolean
+    responsive?: boolean
+    attribute?: boolean
+    max?: boolean
+    breakpoints?: { [k: string]: string }
+  }
+
+  type Vals = string[] | number[] | { [k: string]: string } | { [k: string]: number }
+
+  interface UtilityOptions {
+    vals: Vals
+    prop: string | string[][]
+    prefix?: string
+    suffix?: string
+    hyphenate?: boolean
+    unit?: string
+    transform?: (val: number | string) => number | string
+  }
+
+  type RemovableUtility = 'column.column' | 'column.offset' | 'column.nestedColumn' | 'column.nestedOffset' | 'margin.margin' | 'margin.marginX' | 'margin.marginY' | 'padding.padding' | 'padding.paddingX' | 'padding.paddingY' | 'opacity | background.size' | 'background.position' | 'background.repeat' | 'flex.display' | 'flex.align' | 'flex.direction' | 'flex.justify' | 'flex.wrap' | 'flex.flex' | 'flex.order' | 'flex.orderSpecial' | 'display | float.float' | 'float.clear' | 'overflow' | 'positioning.position' | 'positioning.placement' | 'positioning.zindex' | 'size.size' | 'size.viewportWidth' | 'size.viewportHeight' | 'size.viewportMinWidth' | 'size.viewportMinHeight' | 'size.viewportMaxWidth' | 'size.viewportMaxHeight' | 'size.aspect' | 'type.fontSize' | 'type.lineHeight' | 'type.fontStyle' | 'type.fontWeight' | 'type.textAlign' | 'type.textOverflow' | 'type.textDecoration' | 'type.textTransform' | 'type.verticalAlign' | 'type.whiteSpace' | 'type.textColumn' | 'misc.cursor' | 'misc.userSelect' | 'misc.pointerEvents' | 'dev'
+
+  interface Css {
+    toString: () => string
+    add: (options: gr8.UtilityOptions) => void
+    reset: () => void
+    attach: () => HTMLStyleElement
+    remove: (key: RemovableUtility | RemovableUtility[]) => void
+  }
+}
+
+declare function gr8(options?: gr8.Options): gr8.Css
+
+declare module 'gr8' {
+  export = gr8
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.8",
   "description": "ⓖⓡ⑧ FUNctional CSS shorthand utilities",
   "main": "dist/gr8.js",
+  "types": "./dist/main.d.ts",
   "devDependencies": {
     "browserify": "^14.3.0",
     "colortape": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
     "test": "node tests/index.js | colortape && browserify tests/browser.js | tape-run | colortape",
     "dist-js": "browserify src/index.js -s gr8 | uglifyjs -m -c > dist/gr8.js",
     "dist-css": "node bin/gnr8.js",
+    "dist-types": "cp ./main.d.ts ./dist/main.d.ts",
     "dox": "node bin/dox/index.js",
     "watch-dox": "onchange 'bin/dox/' -- npm run dox",
-    "dist": "npm run dist-js && npm run dist-css && npm run dox"
+    "dist": "npm run dist-js && npm run dist-css && npm run dist-types && npm run dox"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds a TypeScript declaration file for TypeScript projects which use this utility.

I also added a build command that simply copies the declaration file to the dist directory however if the entire repo is published to npm there is no reason why the declarations can't just live in the project root and the `types` key in package.json point to it instead.