### PR TITLE
exclude option

### DIFF
--- a/bin/readme/index.md
+++ b/bin/readme/index.md
@@ -68,9 +68,10 @@ Generate utilities and return a string of css. `opts` accepts the following valu
 - `opts.breakpoints` **[Object]** values for breakpoint utilities
 - `opts.breakpointSelector` **[String | Function]** selector shortcut or css selector template function
 
-#### Custom Utilities Option
+#### Custom Utilities Options
 
 - `opts.utils` **[Array]** custom [gr8-util](https://github.com/jongacnik/gr8-util) utilities
+- `opts.exclude` **[Array]** keys of default utilities to exclude
 
 ## Value Options
 
@@ -234,7 +235,7 @@ var css = gr8({
 
 </details>
 
-## Custom Utilities Option
+## Custom Utilities Options
 
 [gr8-util](https://github.com/jongacnik/gr8-util) is a little function for generating functional css utilities. Given a plain object, concise css utilities are generated. All the utilities in `gr8` are built using this.
 
@@ -309,6 +310,12 @@ var css = gr8({
 </details><br>
 
 **[Refer to gr8-util for further documentation on generating custom utilities.](https://github.com/jongacnik/gr8-util)**
+
+### `opts.exclude`
+
+Use the `exclude` option to remove some of the default utilities. Accepts an array with any of the following values:
+
+{{ utilityKeys }}
 
 ## Proxies
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ var defaults = {
     lg: 1280
   },
   breakpointSelector: 'attribute',
-  utils: []
+  utils: [],
+  exclude: []
 }
 
 function gr8 (options) {

--- a/readme.md
+++ b/readme.md
@@ -439,9 +439,10 @@ Generate utilities and return a string of css. `opts` accepts the following valu
 - `opts.breakpoints` **[Object]** values for breakpoint utilities
 - `opts.breakpointSelector` **[String | Function]** selector shortcut or css selector template function
 
-#### Custom Utilities Option
+#### Custom Utilities Options
 
 - `opts.utils` **[Array]** custom [gr8-util](https://github.com/jongacnik/gr8-util) utilities
+- `opts.exclude` **[Array]** keys of default utilities to exclude
 
 ## Value Options
 
@@ -605,7 +606,7 @@ var css = gr8({
 
 </details>
 
-## Custom Utilities Option
+## Custom Utilities Options
 
 [gr8-util](https://github.com/jongacnik/gr8-util) is a little function for generating functional css utilities. Given a plain object, concise css utilities are generated. All the utilities in `gr8` are built using this.
 
@@ -680,6 +681,12 @@ var css = gr8({
 </details><br>
 
 **[Refer to gr8-util for further documentation on generating custom utilities.](https://github.com/jongacnik/gr8-util)**
+
+### `opts.exclude`
+
+Use the `exclude` option to remove some of the default utilities. Accepts an array with any of the following values:
+
+`column`, `margin`, `padding`, `opacity`, `background`, `flex`, `display`, `float`, `overflow`, `positioning`, `size`, `typography`, `miscellaneous`, `development`
 
 ## Proxies
 

--- a/utils.js
+++ b/utils.js
@@ -36,13 +36,25 @@ var utils = {
 }
 
 function gr8utils (options) {
-  return generate(utils, options)
+  return generate(filter(utils, options.exclude), options)
 }
 
 // public
 gr8utils.defaults = defaults
 gr8utils.utils = utils
 gr8utils.generate = generate
+
+function filter (utils, keys) {
+  if (!Array.isArray(keys)) return utils
+  var allKeys = Object.keys(utils)
+  keys.forEach(function (key) {
+    var isMatch = allKeys.indexOf(key) >= 0
+    if (isMatch) {
+      delete utils[key]
+    }
+  })
+  return utils
+}
 
 function generate (utils, options) {
   options = x(defaults, options)


### PR DESCRIPTION
As per indicated in #18, added an `exclude` option to remove default utilities:

```js
var css = gr8({
  exclude: ['column', 'size', 'development']
})
```

Accepts the following values: `column`, `margin`, `padding`, `opacity`, `background`, `flex`, `display`, `float`, `overflow`, `positioning`, `size`, `typography`, `miscellaneous`, `development`