### PR TITLE
add style field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.3",
   "description": "Functional css utilities",
   "main": "index.js",
+  "style": "dist/gr8.css",
   "devDependencies": {
     "colortape": "^0.1.2",
     "onchange": "^3.2.1",


### PR DESCRIPTION
This allows `sheetify` to find `dist/gr8.css` with just:

```js
var css = require('sheetify')
css('gr8')
```

See [here](https://github.com/stackcss/sheetify#use-npm-packages) for convention.